### PR TITLE
New Versions release for Flair BI Platform

### DIFF
--- a/flair-bi/values.yaml
+++ b/flair-bi/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: flairbi/flairbi
-  tag: v2.5.5
+  tag: v2.6.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/flair-cache/values.yaml
+++ b/flair-cache/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: flairbi/flair-cache
-  tag: v2.2.4
+  tag: v2.6.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/flair-engine/values.yaml
+++ b/flair-engine/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: flairbi/flair-engine
-  tag: v2.5.6
+  tag: v2.6.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/flair-notifications/values.yaml
+++ b/flair-notifications/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: flairbi/flair-notifications
-  tag: 2.5.7
+  tag: 2.5.8
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/flair-registry/values.yaml
+++ b/flair-registry/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: flairbi/flair-registry
-  tag: v5.0.10
+  tag: v7.0.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/gcp/flair-bi.yaml
+++ b/gcp/flair-bi.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  tag: v2.5.5
+  tag: v2.6.0
 
 service:
   type: NodePort

--- a/gcp/flair-cache.yaml
+++ b/gcp/flair-cache.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v2.5.4
+  tag: v2.6.0
 
 resources:
   requests:

--- a/gcp/flair-engine.yaml
+++ b/gcp/flair-engine.yaml
@@ -1,7 +1,7 @@
 replicaCount: 2
 
 image:
-  tag: v2.5.6
+  tag: v2.6.0
 
 resources:
   requests:

--- a/gcp/flair-notifications.yaml
+++ b/gcp/flair-notifications.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  tag: 2.5.7
+  tag: 2.5.8
 
 resources:
   requests:


### PR DESCRIPTION
### Flair BI Platform new versions 

Flair BI :  `v2.6.0`
Flair Engine: `v2.6.0`
Flair Cache: `v2.6.0`
Flair Notifications: `2.5.8`
Flair Registry: `v7.0.0`
