### PR TITLE
New Versions release for Flair BI Platform

### DIFF
--- a/flair-bi/values.yaml
+++ b/flair-bi/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: flairbi/flairbi
-  tag: v2.6.0
+  tag: v2.6.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/flair-notifications/values.yaml
+++ b/flair-notifications/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: flairbi/flair-notifications
-  tag: 2.5.8
+  tag: 2.5.9
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/gcp/flair-bi.yaml
+++ b/gcp/flair-bi.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  tag: v2.6.0
+  tag: v2.6.1
 
 service:
   type: NodePort

--- a/gcp/flair-notifications.yaml
+++ b/gcp/flair-notifications.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  tag: 2.5.8
+  tag: 2.5.9
 
 resources:
   requests:


### PR DESCRIPTION
### Flair BI Platform new versions 

Flair BI :  `v2.6.1`
Flair Engine: `v2.6.0`
Flair Cache: `v2.6.0`
Flair Notifications: `2.5.9`
Flair Registry: `v7.0.0`
