### PR TITLE
New Versions release for Flair BI Platform

### DIFF
--- a/flair-bi/values.yaml
+++ b/flair-bi/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: flairbi/flairbi
-  tag: v2.6.1
+  tag: v2.6.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/flair-notifications/values.yaml
+++ b/flair-notifications/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: flairbi/flair-notifications
-  tag: 2.5.9
+  tag: 2.5.10
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/gcp/flair-bi.yaml
+++ b/gcp/flair-bi.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  tag: v2.6.1
+  tag: v2.6.2
 
 service:
   type: NodePort

--- a/gcp/flair-notifications.yaml
+++ b/gcp/flair-notifications.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  tag: 2.5.9
+  tag: 2.5.10
 
 resources:
   requests:


### PR DESCRIPTION
### Flair BI Platform new versions 

Flair BI :  `v2.6.2`
Flair Engine: `v2.6.0`
Flair Cache: `v2.6.0`
Flair Notifications: `2.5.10`
Flair Registry: `v7.0.0`
